### PR TITLE
Switch Google Maps to Open Streat Maps

### DIFF
--- a/source/_views/meetup.html
+++ b/source/_views/meetup.html
@@ -55,6 +55,7 @@
             var mymap = L.map('map_canvas').setView(venue_location, 17);
             L.tileLayer('//{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
                 maxZoom: 20,
+                scrollWheelZoom: false,
                 attribution: 'Map data &copy; <a href="https://openstreetmap.org">OpenStreetMap</a> contributors, ' +
                 '<a href="https://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, ' +
                 'Imagery © <a href="https://mapbox.com">Mapbox</a>',

--- a/source/_views/meetup.html
+++ b/source/_views/meetup.html
@@ -43,17 +43,28 @@
         <!-- Map -->
         <div id="map_canvas" style="width:100%;height:300px;"></div>
 
-        <script type="text/javascript" src="//maps.google.com/maps/api/js?language=en&sensor=false"></script>
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.3.1/dist/leaflet.css"
+          integrity="sha512-Rksm5RenBEKSKFjgI3a41vrjkw4EVPlJ3+OiI65vTjIdo9brlAacEuKOiQ5OFh7cOI1bkDwLqdLw3Zg0cRJAAQ=="
+          crossorigin=""/>
+    <!-- Make sure you put this AFTER Leaflet's CSS -->
+    <script src="https://unpkg.com/leaflet@1.3.1/dist/leaflet.js"
+            integrity="sha512-/Nsx9X4HebavoBvEBuyp3I7od5tA0UzAxs+j83KgC8PU0kgB4XiK4Lfe4y4cgBtaRJQEIFCW+oC506aPT2L1zw=="
+            crossorigin=""></script>
         <script type="text/javascript">
-         var map_545b78b925333 = new google.maps.Map(document.getElementById("map_canvas"), {"mapTypeId":google.maps.MapTypeId.ROADMAP,"zoom":17,"disableDefaultUI":true,"disableDoubleClickZoom":true});
-         var venue_location = new google.maps.LatLng({{ page.venue.location }}, true);
-         map_545b78b925333.setCenter(venue_location);
-         var marker = new google.maps.Marker({
-               position: venue_location,
-               map: map_545b78b925333,
-               title: 'PHPers'
-            });
-         var closable_info_windows = Array();
+            var venue_location = [{{ page.venue.location }}];
+            var mymap = L.map('map_canvas').setView(venue_location, 17);
+            L.tileLayer('//{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+                maxZoom: 20,
+                attribution: 'Map data &copy; <a href="https://openstreetmap.org">OpenStreetMap</a> contributors, ' +
+                '<a href="https://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, ' +
+                'Imagery © <a href="https://mapbox.com">Mapbox</a>',
+                id: 'examples.map-i875mjb7'
+            }).addTo(mymap);
+
+            L.marker(venue_location).addTo(mymap)
+                .bindPopup('{{ page.title }} <br> Godz.: {{ page.time }} <br> {{ page.venue.short }}')
+                .openPopup();
+
         </script>
         <!-- End Map -->
 </section><!-- END CONTAINER -->
@@ -63,7 +74,9 @@
         <h1 class="meeting-box">Sponsorzy</h1>
         {% for sponsor in page.sponsors %}
         <div class="description five columns">
+            {% if sponsor.name %}
             <h1><a href="{{ sponsor.site }}" target="_blank">{{ sponsor.name }}</a></h1>
+            {% endif %}
             {% if sponsor.logo %}
             <div><a href="{{ sponsor.site }}" target="_blank"><img src="{{ sponsor.logo }}" /></a></div>
             {% endif %}


### PR DESCRIPTION
Replaces Google Maps by Open Streat maps using [LeafletJS](https://leafletjs.com/)